### PR TITLE
* Add "source /accre/usr/bin/setup_accre_runtime_dir" to rstudio_new …

### DIFF
--- a/rstudio_new/template/before.sh.erb
+++ b/rstudio_new/template/before.sh.erb
@@ -10,3 +10,6 @@ port=$(find_port ${host})
 # Define a password and export it for RStudio authentication
 password="$(create_passwd 16)"
 export RSTUDIO_PASSWORD="${password}"
+
+# Setup ACCRE_RUNTIME_DIR
+source /accre/usr/bin/setup_accre_runtime_dir


### PR DESCRIPTION
…because it wasn't setting the bind mount for /tmp correctly without it