### PR TITLE
Removed temporary messaging for dgx users.

### DIFF
--- a/accre_jupyter/manifest.yml
+++ b/accre_jupyter/manifest.yml
@@ -21,5 +21,3 @@ description: |
   from the provided software stack, you may use that instead by selecting the option
   to bring your own virtual environment.
 
-  NOTICE - for access to the DGX hardware, please use the legacy Jupyter Notebook GPU app for now as 
-  we are still working on a permanent resource management structure for this hardware.

--- a/accre_rstudio/manifest.yml
+++ b/accre_rstudio/manifest.yml
@@ -6,5 +6,3 @@ role: batch_connect
 description: |
   This app will launch RStudio Server on an ACCRE compute node using an apptainer container.
 
-  NOTICE - for access to the DGX hardware, please use the legacy Rstudio Server GPU App for now
-  as we are still working on a permanent resource management structure for this hardware.

--- a/desktop/accre.yml
+++ b/desktop/accre.yml
@@ -11,9 +11,6 @@ description: |
   between portal sessions until you delete or logout, so you may use the same
   desktop for several days.
 
-  NOTICE - for access to the DGX hardware, please use the legacy ACCRE GPU
-  for now as we are still working on a permanent resource management structure
-  for this hardware.
 cluster: "accre"
 attributes:
   desktop: "xfce"

--- a/desktop/accre_gpu_legacy.yml
+++ b/desktop/accre_gpu_legacy.yml
@@ -3,10 +3,7 @@ title: "[legacy] ACCRE GPU Desktop"
 description: |
   NOTICE - This is a legacy application left available temporarily for
   compatibility with existing workflows. We recommend that you use the
-  new ACCRE Desktop app instead as soon as is practical. Note that at
-  present this app is still required to access the DGX hardware as we
-  are still setting up a permanent resource access structure for these
-  machines.
+  new ACCRE Desktop app instead as soon as is practical.
   
   This is an experimental feature!!! This app will launch an interactive
   desktop on an ACCRE GPU node. You must have GPU access to use this app.


### PR DESCRIPTION
This pull request removes outdated notices about DGX hardware access from several app manifest files, reflecting changes in resource management and improving clarity for users. See RT95258 for more info.

Manifest notice updates:

* Removed the notice about using legacy apps for DGX hardware access from the `accre_jupyter/manifest.yml` description.
* Removed the notice about using the legacy RStudio Server GPU app for DGX hardware from the `accre_rstudio/manifest.yml` description.
* Removed the notice about using the legacy ACCRE GPU app for DGX hardware from the `desktop/accre.yml` description.
* Updated the legacy notice in `desktop/accre_gpu_legacy.yml` to remove the statement about DGX hardware access requirements, making the description more current.