### PR TITLE
Add /v5000 bind mount to accre_rstudio and accre_jupyter containers

### DIFF
--- a/accre_jupyter/template/script.sh.erb
+++ b/accre_jupyter/template/script.sh.erb
@@ -63,8 +63,8 @@ unset accre_jupyter_mc
   mkdir -p ${HOME}/.local
   mkdir -p ${ACCRE_RUNTIME_DIR}/.local
   <%- if context[:partition].to_s.strip == 'batch_gpu' || context[:partition].to_s.strip == 'interactive_gpu' -%>
-    apptainer exec --nv -B ${ACCRE_RUNTIME_DIR}/.local:${HOME}/.local,/accre,/cvmfs,/data,/nobackup,/labs,/panfs <%= context.apptainer %>  jupyter lab --config="${CONFIG_FILE}" --ip="0.0.0.0" --notebook-dir=${accre_notebook_dir} <%= context.extra_jupyter_args %>
+    apptainer exec --nv -B ${ACCRE_RUNTIME_DIR}/.local:${HOME}/.local,/accre,/cvmfs,/data,/nobackup,/labs,/panfs,/v5000 <%= context.apptainer %>  jupyter lab --config="${CONFIG_FILE}" --ip="0.0.0.0" --notebook-dir=${accre_notebook_dir} <%= context.extra_jupyter_args %>
   <%- else -%>
-    apptainer exec -B ${ACCRE_RUNTIME_DIR}/.local:${HOME}/.local,/accre,/cvmfs,/data,/nobackup,/labs,/panfs <%= context.apptainer %>  jupyter lab --config="${CONFIG_FILE}" --ip="0.0.0.0" --notebook-dir=${accre_notebook_dir} <%= context.extra_jupyter_args %>
+    apptainer exec -B ${ACCRE_RUNTIME_DIR}/.local:${HOME}/.local,/accre,/cvmfs,/data,/nobackup,/labs,/panfs,/v5000 <%= context.apptainer %>  jupyter lab --config="${CONFIG_FILE}" --ip="0.0.0.0" --notebook-dir=${accre_notebook_dir} <%= context.extra_jupyter_args %>
   <%- end -%>
 <%- end -%>

--- a/accre_rstudio/template/script.sh.erb
+++ b/accre_rstudio/template/script.sh.erb
@@ -79,7 +79,7 @@ echo "Starting up rserver at $(date) ..."
 <%- if context[:partition].to_s.strip == 'batch_gpu' || context[:partition].to_s.strip == 'interactive_gpu' -%>
 apptainer exec \
    --nv \
-   --bind ${RSESSION_PATH}/run:/run,${RSESSION_PATH}/var-lib-rstudio-server:/var/lib/rstudio-server,${RSESSION_PATH}/etc_rstudio:/etc/rstudio,${ACCRE_RUNTIME_DIR}:/tmp,/accre,/cvmfs,/data,/nobackup,/labs,/panfs \
+   --bind ${RSESSION_PATH}/run:/run,${RSESSION_PATH}/var-lib-rstudio-server:/var/lib/rstudio-server,${RSESSION_PATH}/etc_rstudio:/etc/rstudio,${ACCRE_RUNTIME_DIR}:/tmp,/accre,/cvmfs,/data,/nobackup,/labs,/panfs,/v5000 \
    "${RSTUDIO_SERVER_IMAGE}" /usr/lib/rstudio-server/bin/rserver \
    --auth-encrypt-password 0 \
    --auth-none 0 \
@@ -90,7 +90,7 @@ apptainer exec \
    --rsession-path "${RSESSION_WRAPPER_FILE}"
 <%- else -%>
 apptainer exec \
-   --bind ${RSESSION_PATH}/run:/run,${RSESSION_PATH}/var-lib-rstudio-server:/var/lib/rstudio-server,${RSESSION_PATH}/etc_rstudio:/etc/rstudio,${ACCRE_RUNTIME_DIR}:/tmp,/accre,/cvmfs,/data,/nobackup,/labs,/panfs \
+   --bind ${RSESSION_PATH}/run:/run,${RSESSION_PATH}/var-lib-rstudio-server:/var/lib/rstudio-server,${RSESSION_PATH}/etc_rstudio:/etc/rstudio,${ACCRE_RUNTIME_DIR}:/tmp,/accre,/cvmfs,/data,/nobackup,/labs,/panfs,/v5000 \
    "${RSTUDIO_SERVER_IMAGE}" /usr/lib/rstudio-server/bin/rserver \
    --auth-encrypt-password 0 \
    --auth-none 0 \


### PR DESCRIPTION
This pull request updates the container bind mounts in the startup scripts for both Jupyter Lab and RStudio Server on ACCRE. The main change is the addition of the `/v5000` directory to the list of bind mounts, ensuring this directory is accessible inside the container environments for both GPU and non-GPU partitions. See RT[98033](https://helpdesk.accre.vanderbilt.edu/Ticket/Display.html?id=98033) for more info.

Verified fix on vizqa.

Bind mount updates:

* Added `/v5000` to the `apptainer exec` bind mount list in the Jupyter Lab startup script for both GPU and non-GPU partitions in `accre_jupyter/template/script.sh.erb`.
* Added `/v5000` to the `apptainer exec` bind mount list in the RStudio Server startup script for both GPU and non-GPU partitions in `accre_rstudio/template/script.sh.erb`. [[1]](diffhunk://#diff-9aa0702621c466bca3e2a7a7199b51ddb2a19e39fb14fdd3d49ecf201e1e46a7L82-R82) [[2]](diffhunk://#diff-9aa0702621c466bca3e2a7a7199b51ddb2a19e39fb14fdd3d49ecf201e1e46a7L93-R93)