### PR TITLE
ood partition validation

### DIFF
--- a/accre_jupyter/submit.yml.erb
+++ b/accre_jupyter/submit.yml.erb
@@ -1,6 +1,22 @@
 # Job submission configuration file
 #
 ---
+<%
+  valid_partitions = %w[batch batch_gpu interactive interactive_gpu]
+  unless valid_partitions.include?(partition.to_s.strip)
+    raise <<~MSG
+      Partition value missing or invalid (received: #{partition.inspect}).
+
+      This is almost always caused by using "Relaunch" on a previous session from
+      "My Interactive Sessions". A known OnDemand issue drops the partition value
+      on Relaunch for apps with advanced form widgets, which produces a job with
+      no --partition / --mem / --cpus-per-task flags and will fail to start.
+
+      Please instead: go to Interactive Apps -> ACCRE JupyterLab, fill out the
+      form fresh, and click Launch.
+    MSG
+  end
+%>
 
 #
 # Configure the content of the job script for the batch job here

--- a/accre_rstudio/submit.yml.erb
+++ b/accre_rstudio/submit.yml.erb
@@ -1,4 +1,20 @@
 ---
+<%
+  valid_partitions = %w[batch batch_gpu interactive interactive_gpu]
+  unless valid_partitions.include?(partition.to_s.strip)
+    raise <<~MSG
+      Partition value missing or invalid (received: #{partition.inspect}).
+
+      This is almost always caused by using "Relaunch" on a previous session from
+      "My Interactive Sessions". A known OnDemand issue drops the partition value
+      on Relaunch for apps with advanced form widgets, which produces a job with
+      no --partition / --mem / --cpus-per-task flags and will fail to start.
+
+      Please instead: go to Interactive Apps -> ACCRE RStudio Server, fill out
+      the form fresh, and click Launch.
+    MSG
+  end
+%>
 
 batch_connect:
   template: "basic"

--- a/desktop/accre_gpu_legacy.yml
+++ b/desktop/accre_gpu_legacy.yml
@@ -25,7 +25,6 @@ attributes:
     label: "GPU Architecture"
     widget: select
     options:
-      - ["Maxwell", "maxwell"]
       - ["Pascal", "pascal"]
       - ["Turing", "turing"]
       - ["A6000", "a6000"]

--- a/desktop/submit/gpu_submit.yml.erb
+++ b/desktop/submit/gpu_submit.yml.erb
@@ -24,11 +24,6 @@ script:
     - "--cpus-per-task=<%= 2 * num_gpus.to_i %>"
 # SM: not sure if the GPU type is right, may need updating
     - "--gres=gpu:nvidia_titan_x:<%= num_gpus.to_i %>"
-<% elsif gpu_arch == "maxwell" -%>
-    - "--mem=<%= 29 * num_gpus.to_i %>G"
-    - "--cpus-per-task=<%= 3 * num_gpus.to_i %>"
-# SM: not sure if the GPU type is right, may need updating
-    - "--gres=gpu:nvidia_geforce_gtx_titan_x:<%= num_gpus.to_i %>"
 <% elsif gpu_arch == "turing" -%>
     - "--mem=<%= 90 * num_gpus.to_i %>G"
     - "--cpus-per-task=<%= 6 * num_gpus.to_i %>"

--- a/jupyter_gpu/form.yml
+++ b/jupyter_gpu/form.yml
@@ -24,7 +24,6 @@ attributes:
     label: "GPU Architecture"
     widget: select
     options:
-      - ["Maxwell", "maxwell"]
       - ["Pascal", "pascal"]
       - ["Turing", "turing"]
       - ["A6000", "a6000"]

--- a/jupyter_gpu/submit.yml.erb
+++ b/jupyter_gpu/submit.yml.erb
@@ -46,11 +46,6 @@ script:
     - "--cpus-per-task=<%= 2 * num_gpus.to_i %>"
 # SM: not sure if the GPU type is right, may need updating
     - "--gres=gpu:nvidia_titan_x:<%= num_gpus.to_i %>"
-<% elsif gpu_arch == "maxwell" -%>
-    - "--mem=<%= 29 * num_gpus.to_i %>G"
-    - "--cpus-per-task=<%= 3 * num_gpus.to_i %>"
-# SM: not sure if the GPU type is right, may need updating
-    - "--gres=gpu:nvidia_geforce_gtx_titan_x:<%= num_gpus.to_i %>"
 <% elsif gpu_arch == "turing" -%>
     - "--mem=<%= 90 * num_gpus.to_i %>G"
     - "--cpus-per-task=<%= 6 * num_gpus.to_i %>"

--- a/jupyter_singularity_gpu/form.yml
+++ b/jupyter_singularity_gpu/form.yml
@@ -26,7 +26,6 @@ attributes:
     label: "GPU Architecture"
     widget: select
     options:
-      - ["Maxwell", "maxwell"]
       - ["Pascal", "pascal"]
       - ["Turing", "turing"]
       - ["A6000", "a6000"]

--- a/jupyter_singularity_gpu/submit.yml.erb
+++ b/jupyter_singularity_gpu/submit.yml.erb
@@ -46,11 +46,6 @@ script:
     - "--cpus-per-task=<%= 2 * num_gpus.to_i %>"
 # SM: not sure if the GPU type is right, may need updating
     - "--gres=gpu:nvidia_titan_x:<%= num_gpus.to_i %>"
-<% elsif gpu_arch == "maxwell" -%>
-    - "--mem=<%= 29 * num_gpus.to_i %>G"
-    - "--cpus-per-task=<%= 3 * num_gpus.to_i %>"
-# SM: not sure if the GPU type is right, may need updating
-    - "--gres=gpu:nvidia_geforce_gtx_titan_x:<%= num_gpus.to_i %>"
 <% elsif gpu_arch == "turing" -%>
     - "--mem=<%= 90 * num_gpus.to_i %>G"
     - "--cpus-per-task=<%= 6 * num_gpus.to_i %>"

--- a/rstudio_gpu/submit.yml.erb
+++ b/rstudio_gpu/submit.yml.erb
@@ -25,11 +25,6 @@ script:
     - "--cpus-per-task=<%= 2 * num_gpus.to_i %>"
 # SM: not sure if the GPU type is right, may need updating
     - "--gres=gpu:nvidia_titan_x:<%= num_gpus.to_i %>"
-<% elsif gpu_arch == "maxwell" -%>
-    - "--mem=<%= 29 * num_gpus.to_i %>G"
-    - "--cpus-per-task=<%= 3 * num_gpus.to_i %>"
-# SM: not sure if the GPU type is right, may need updating
-    - "--gres=gpu:nvidia_geforce_gtx_titan_x:<%= num_gpus.to_i %>"
 <% elsif gpu_arch == "turing" -%>
     - "--mem=<%= 90 * num_gpus.to_i %>G"
     - "--cpus-per-task=<%= 6 * num_gpus.to_i %>"


### PR DESCRIPTION
This pull request introduces validation for the partition field in ACCRE Jupyter and RStudio job submission templates to prevent job misconfiguration, and removes support for the "Maxwell" GPU architecture across all relevant forms and submission scripts. See RT[98698](https://helpdesk.accre.vanderbilt.edu/Ticket/Display.html?id=98698) and RT[96777](https://helpdesk.accre.vanderbilt.edu/Ticket/Display.html?id=96777) for more information. Changes were tested on vizqa.

The most important changes are:

Partition validation improvements:

* Added validation logic to `accre_jupyter/submit.yml.erb` and `accre_rstudio/submit.yml.erb` to ensure the `partition` value is set to a valid option, with a clear error message to guide users in case of misconfiguration [[1]](diffhunk://#diff-42d2a629d3066f1aefbcd75420bfe8545a81ac29a2f347d1168dc7c310d05da5R4-R19) [[2]](diffhunk://#diff-ce6383b994e43ed07f1ac03711c62d5aa2f400e1fdd4c068555dddd2607fa801R2-R17).

GPU architecture options cleanup:

* Removed the "Maxwell" GPU architecture option from all form files (`desktop/accre_gpu_legacy.yml`, `jupyter_gpu/form.yml`, `jupyter_singularity_gpu/form.yml`) to prevent users from selecting unsupported hardware [[1]](diffhunk://#diff-1cacf492a2f106c85b589a888ddf6069a0b69d10f1b6fa8cc642e8b3b2281bf9L28) [[2]](diffhunk://#diff-cadb92cf5bc37e19df134b038687502b264e8fcd0931d012ab0797b109af6f1aL27) [[3]](diffhunk://#diff-e6373437d99803eea02bfc46e7e2fca5dfbf74c0551c44bb5c20e856a7a4fe1dL29).
* Removed all submission script logic and resource flag generation related to the "Maxwell" GPU architecture from GPU job submission templates (`desktop/submit/gpu_submit.yml.erb`, `jupyter_gpu/submit.yml.erb`, `jupyter_singularity_gpu/submit.yml.erb`, `rstudio_gpu/submit.yml.erb`) [[1]](diffhunk://#diff-34d484f2802e3b851f4d5575a5d78d2528c4a3e1eaa1dd3c1213d32f6ae8c064L27-L31) [[2]](diffhunk://#diff-d08ffd5bed1f55faa05de8e4970e5f6efaef8ab423031d703934e15aacb6115eL49-L53) [[3]](diffhunk://#diff-12ce15f5667bd88eec90724359d21582bc0468d856f21c635f0c32ec8da4490cL49-L53) [[4]](diffhunk://#diff-8dcedc962391e382e43377f06a1c779e63ffa40b0793558e55326dcaabd8e603L28-L32).