### PR TITLE
Add Nvidia H200 option to accre OOD apps

### DIFF
--- a/accre_jupyter/form.yml
+++ b/accre_jupyter/form.yml
@@ -99,6 +99,7 @@ attributes:
       - [ 'Nvidia RTX A6000', 'nvidia_rtx_a6000' ]
       - [ 'Nvidia RTX A4000', 'nvidia_rtx_a4000' ]
       - [ 'Nvidia H100', 'nvidia_h100_nvl' ]
+      - [ 'Nvidia H200', 'nvidia_h200' ]
       - [ 'Nvidia A100 (80GB)', 'nvidia_a100_80gb' ]
       - [ 'Nvidia L40S', 'nvidia_l40s' ]
       - [ 'Nvidia Quadro RTX 6000', 'quadro_rtx_6000' ]

--- a/accre_jupyter/submit.yml.erb
+++ b/accre_jupyter/submit.yml.erb
@@ -89,6 +89,9 @@ script:
       <% elsif gpus_type == "nvidia_h100_nvl" %>
     - "--mem=<%= numgpus.to_i * 561 %>G"
     - "--cpus-per-task=<%= numgpus.to_i * 32 %>"
+      <% elsif gpus_type == "nvidia_h200" %>
+    - "--mem=<%= numgpus.to_i * 280 %>G"
+    - "--cpus-per-task=<%= numgpus.to_i * 28 %>"
       <% elsif gpus_type == "nvidia_a100_80gb" %>
     - "--mem=<%= numgpus.to_i * 374 %>G"
     - "--cpus-per-task=<%= numgpus.to_i * 32 %>"

--- a/accre_rstudio/form.yml
+++ b/accre_rstudio/form.yml
@@ -105,6 +105,7 @@ attributes:
       - [ 'Nvidia RTX A6000', 'nvidia_rtx_a6000' ]
       - [ 'Nvidia RTX A4000', 'nvidia_rtx_a4000' ]
       - [ 'Nvidia H100', 'nvidia_h100_nvl' ]
+      - [ 'Nvidia H200', 'nvidia_h200' ]
       - [ 'Nvidia A100 (80GB)', 'nvidia_a100_80gb' ]
       - [ 'Nvidia L40S', 'nvidia_l40s' ]
       - [ 'Nvidia Quadro RTX 6000', 'quadro_rtx_6000' ]

--- a/accre_rstudio/submit.yml.erb
+++ b/accre_rstudio/submit.yml.erb
@@ -70,6 +70,9 @@ script:
       <% elsif gpus_type == "nvidia_h100_nvl" %>
     - "--mem=<%= numgpus.to_i * 561 %>G"
     - "--cpus-per-task=<%= numgpus.to_i * 32 %>"
+      <% elsif gpus_type == "nvidia_h200" %>
+    - "--mem=<%= numgpus.to_i * 280 %>G"
+    - "--cpus-per-task=<%= numgpus.to_i * 28 %>"
       <% elsif gpus_type == "nvidia_a100_80gb" %>
     - "--mem=<%= numgpus.to_i * 374 %>G"
     - "--cpus-per-task=<%= numgpus.to_i * 32 %>"

--- a/desktop/accre.yml
+++ b/desktop/accre.yml
@@ -89,6 +89,7 @@ attributes:
       - [ 'Nvidia RTX A6000', 'nvidia_rtx_a6000' ]
       - [ 'Nvidia RTX A4000', 'nvidia_rtx_a4000' ]
       - [ 'Nvidia H100', 'nvidia_h100_nvl' ]
+      - [ 'Nvidia H200', 'nvidia_h200' ]
       - [ 'Nvidia A100 (80GB)', 'nvidia_a100_80gb' ]
       - [ 'Nvidia L40S', 'nvidia_l40s' ]
       - [ 'Nvidia Quadro RTX 6000', 'quadro_rtx_6000' ]

--- a/desktop/submit/accre_submit.yml.erb
+++ b/desktop/submit/accre_submit.yml.erb
@@ -51,6 +51,9 @@ script:
       <% elsif gpus_type == "nvidia_h100_nvl" %>
     - "--mem=<%= numgpus.to_i * 561 %>G"
     - "--cpus-per-task=<%= numgpus.to_i * 32 %>"
+      <% elsif gpus_type == "nvidia_h200" %>
+    - "--mem=<%= numgpus.to_i * 280 %>G"
+    - "--cpus-per-task=<%= numgpus.to_i * 28 %>"
       <% elsif gpus_type == "nvidia_a100_80gb" %>
     - "--mem=<%= numgpus.to_i * 374 %>G"
     - "--cpus-per-task=<%= numgpus.to_i * 32 %>"


### PR DESCRIPTION
## Summary
- Add H200 (`nvidia_h200`) option to the GPU type selector in `accre_jupyter`, `accre_rstudio`, and `desktop`.
- Per-GPU resources match hgx03's node spec: 28 cores (`RestrictedCoresPerGPU`), 280 GB memory (`(RealMemory - MemSpecLimit) / 8` rounded down).
- Marked WIP until vizqa testing confirms the form renders, the option submits the right `--gres`/`--mem`/`--cpus-per-task`, and a session can actually start on hgx03.

## Test plan
- [x] Deploy on vizqa (copy app dirs into the running OOD app paths)
- [x] Verify H200 appears in the GPU Type dropdown for accre_jupyter, accre_rstudio, and desktop
- [x] Submit a 1-GPU H200 job from each app (with a fe_accre_lab_acc account); confirm sbatch gets `--partition=batch_gpu --gres=gpu:nvidia_h200:1 --mem=280G --cpus-per-task=28`
- [x] Submit a 2-GPU H200 job; confirm scaling (`--mem=560G --cpus-per-task=56`)
- [x] Confirm session reaches hgx03 and starts the app (Jupyter/RStudio/desktop)

See RT[98771](https://helpdesk.accre.vanderbilt.edu/Ticket/Display.html?id=98771) for more info.